### PR TITLE
retry var declaration

### DIFF
--- a/EventSource.js
+++ b/EventSource.js
@@ -10,7 +10,6 @@ var EventSource = function (url, options) {
   var eventsource = this,
       interval = 500, // polling interval
       lastEventId = null,
-      retry = 0,
       cache = '',
       eventType;
 
@@ -69,6 +68,7 @@ var EventSource = function (url, options) {
           var parts = responseText.substr(cache.length).split("\n"),
               data = [],
               i = 0,
+              retry = 0,
               line = '';
 
           cache = responseText;


### PR DESCRIPTION
There's a small bug in react-native-event-source that occurs when retry comes into play. The `retry` var is never declared. I've added a `var retry = 0` declaration prior to parsing `parts`.