### PR TITLE
Give RNEventSource a default (empty) options param

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import EventSource from './EventSource'
 
 class RNEventSource {
-  constructor(url, options) {
+  constructor(url, options={}) {
     this.url         = url;
     this.options     = options;
     this.eventSource = new EventSource(url, options);


### PR DESCRIPTION
Underlying EventSource fails when not passed options, by giving RNEventSource a default options parameter, EventSource gets passed it through RNEventSources constructor