### PR TITLE
Update EventSource to support chunked data

### DIFF
--- a/EventSource.js
+++ b/EventSource.js
@@ -81,8 +81,6 @@ var EventSource = function(url, options) {
             line = '';
           lastIndexProcessed = responseText.lastIndexOf('\n\n') + 2;
 
-          seenBytes = responseText.length;
-
           // TODO handle 'event' (for buffer name), retry
           for (; i < parts.length; i++) {
             line = parts[i].replace(reTrim, '');


### PR DESCRIPTION
This code doesn't work when a line comes in but it hasn't finished. In that case, the `split('\n')` call will give you some junk data which the rest of the logic can't handle.

There might be another edge case where the XHR request finishes before the full line comes in but that's outside the scope of this change