### PR TITLE
Add support of connection error event

### DIFF
--- a/EventSource.js
+++ b/EventSource.js
@@ -118,6 +118,11 @@ var EventSource = function(url, options) {
         } else if (eventsource.readyState !== eventsource.CLOSED) {
           if (this.readyState == 4) {
             // and some other status
+            eventsource.dispatchEvent('connection-error', {
+              type: 'connection-error',
+              status: this.status,
+              message: this.responseText,
+            });
             pollAgain(interval);
           } else if (this.readyState == 0) {
             // likely aborted

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ class MyApp extends Component {
       console.log(data.type); // message
       console.log(data.data);
     });
+
+    // Grab connection error events with the type of 'connection-error'
+    this.eventSource.addEventListener('connection-error', (data) => {
+      console.log(data.message); // message
+      console.log(data.status); // http status code
+    });
   }
   componentWillUnmount() {
     this.eventSource.removeAllListeners();


### PR DESCRIPTION
When server response with 401 status code we can catch this event and show "wrong credentials" message to user instead of unlimited tries of reconnections.